### PR TITLE
NEURODAMUS_ENABLE_REPORTING=OFF option to skip reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  SONATA_REPORT_VERSION: '1.2.3'
+  SONATA_REPORT_VERSION: '2.0.0'
 
 jobs:
   build:
@@ -65,6 +65,7 @@ jobs:
         python -m pip install NEURON-nightly neurodamus
 
     - name: Cache SONATA™ reporting library build
+      if: matrix.enable_reporting != 'OFF'
       id: cache-libsonatareport
       uses: actions/cache@v3
       env:
@@ -74,9 +75,9 @@ jobs:
         key: build-reports-${{ env.SONATA_REPORT_VERSION}}
 
     - name: Install SONATA™ reporting library
-      if: steps.cache-libsonatareport.outputs.cache-hit != 'true'
+      if: matrix.enable_reporting != 'OFF' && steps.cache-libsonatareport.outputs.cache-hit != 'true'
       run: |
-        gh repo clone BlueBrain/libsonatareport $HOME/reports/src -- --recursive --shallow-submodules --branch ${{ env.SONATA_REPORT_VERSION }}
+        gh repo clone openbraininstitute/libsonatareport $HOME/reports/src -- --recursive --shallow-submodules --branch ${{ env.SONATA_REPORT_VERSION }}
         cmake \
           -B $HOME/reports/build \
           -S $HOME/reports/src \
@@ -107,7 +108,7 @@ jobs:
           -DNEURODAMUS_NCX_METABOLISM=${{ matrix.metabolism || 'OFF' }} \
           -DNEURODAMUS_NCX_NGV=${{ matrix.ngv || 'OFF' }} \
           -DNEURODAMUS_NCX_PLASTICITY=${{ matrix.plasticity || 'OFF' }} \
-          -DNEURODAMUS_NCX_V5=${{ matrix.v5 || 'OFF'}}
+          -DNEURODAMUS_NCX_V5=${{ matrix.v5 || 'OFF'}} \
           -DNEURODAMUS_ENABLE_REPORTING=${{ matrix.enable_reporting || 'ON' }}
 
     - name: Build and install models

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
         ngv: ['OFF']
         plasticity: ['OFF']
         v5: ['OFF']
+        enable_reporting: ['ON']
         include:
           - model: 'neocortex'
             coreneuron: 'OFF'
@@ -26,6 +27,13 @@ jobs:
             ngv: 'ON'
             plasticity: 'OFF'
             v5: 'OFF'
+          - model: 'neocortex'
+            coreneuron: 'OFF'
+            metabolism: 'ON'
+            ngv: 'ON'
+            plasticity: 'OFF'
+            v5: 'OFF'
+            enable_reporting: 'OFF'
           - model: 'neocortex'
             coreneuron: 'ON'
             metabolism: 'OFF'
@@ -85,10 +93,14 @@ jobs:
         export CC=$(which mpicc)
         export CXX=$(which mpicxx)
         DATADIR=$(python -c "import neurodamus; from pathlib import Path; print(Path(neurodamus.__file__).parent / 'data')")
+        if [ "${{ matrix.enable_reporting || 'ON' }}" = "ON" ]; then
+          REPORTING_OPTS="-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_PREFIX_PATH=$HOME/reports/install"
+        else
+          REPORTING_OPTS=""
+        fi
         cmake -B build -S . \
           -DCMAKE_INSTALL_PREFIX=$PWD/install \
-          -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
-          -DCMAKE_PREFIX_PATH=$HOME/reports/install \
+          ${REPORTING_OPTS} \
           -DNEURODAMUS_CORE_DIR=${DATADIR} \
           -DNEURODAMUS_ENABLE_CORENEURON=${{ matrix.coreneuron }} \
           -DNEURODAMUS_MECHANISMS=${{ matrix.model }} \
@@ -96,6 +108,7 @@ jobs:
           -DNEURODAMUS_NCX_NGV=${{ matrix.ngv || 'OFF' }} \
           -DNEURODAMUS_NCX_PLASTICITY=${{ matrix.plasticity || 'OFF' }} \
           -DNEURODAMUS_NCX_V5=${{ matrix.v5 || 'OFF'}}
+          -DNEURODAMUS_ENABLE_REPORTING=${{ matrix.enable_reporting || 'ON' }}
 
     - name: Build and install models
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ option(NEURODAMUS_NCX_METABOLISM OFF)
 option(NEURODAMUS_NCX_NGV OFF)
 option(NEURODAMUS_NCX_PLASTICITY OFF)
 option(NEURODAMUS_NCX_V5 OFF)
+option(NEURODAMUS_ENABLE_REPORTING "enable reporting with libsonatareport" ON)
 
 # NEURON does not install any CMake glue, we have to manually find nrnivmodl
 find_program(nrnivmodl nrnivmodl REQUIRED)
@@ -136,22 +137,29 @@ foreach(_input_dir IN LISTS input_mod_directories)
   endforeach()
 endforeach()
 
-# At some point in the 1.14 series, HDF5 decided that the HDF5_*LIBRARIES
-# variables should contain _targets_, not library names/paths.
-set(HDF5_NO_FIND_PACKAGE_CONFIG_FILE ON)
-find_package(HDF5 REQUIRED)
-find_package(sonata REQUIRED)
+if(NEURODAMUS_ENABLE_REPORTING)
+  message(STATUS "Enable reporting with libsonatareport")
+  # At some point in the 1.14 series, HDF5 decided that the HDF5_*LIBRARIES
+  # variables should contain _targets_, not library names/paths.
+  set(HDF5_NO_FIND_PACKAGE_CONFIG_FILE ON)
+  find_package(HDF5 REQUIRED)
+  find_package(sonata REQUIRED)
 
-set(nrn_incflags "-isystem ${sonatareport_INCLUDE_DIR}")
-get_filename_component(_report_dir "${sonatareport_LIBRARY}" DIRECTORY)
-set(nrn_loadflags "-Wl,-rpath,'${_report_dir}' '${sonatareport_LIBRARY}'")
-foreach(dir IN LISTS HDF5_INCLUDE_DIRS)
-  set(nrn_incflags "${nrn_incflags} -isystem '${dir}'")
-endforeach()
-foreach(lib IN LISTS HDF5_C_LIBRARIES)
-  get_filename_component(_lib_dir "${lib}" DIRECTORY)
-  set(nrn_loadflags "${nrn_loadflags} -Wl,-rpath,'${_lib_dir}' '${lib}'")
-endforeach()
+  set(nrn_incflags "-isystem ${sonatareport_INCLUDE_DIR}")
+  get_filename_component(_report_dir "${sonatareport_LIBRARY}" DIRECTORY)
+  set(nrn_loadflags "-Wl,-rpath,'${_report_dir}' '${sonatareport_LIBRARY}'")
+  foreach(dir IN LISTS HDF5_INCLUDE_DIRS)
+    set(nrn_incflags "${nrn_incflags} -isystem '${dir}'")
+  endforeach()
+  foreach(lib IN LISTS HDF5_C_LIBRARIES)
+    get_filename_component(_lib_dir "${lib}" DIRECTORY)
+    set(nrn_loadflags "${nrn_loadflags} -Wl,-rpath,'${_lib_dir}' '${lib}'")
+  endforeach()
+else()
+  message(STATUS "Disable reporting")
+  set(nrn_incflags "${nrn_incflags} -DDISABLE_REPORTINGLIB")
+  set(nrn_loadflags "")
+endif()
 
 configure_file(build_neurodamus.sh.in build_neurodamus.sh @ONLY)
 


### PR DESCRIPTION
1. New cmake NEURODAMUS_ENABLE_REPORTING option, fix #13
2. Update libsonatareport report URL to OBI, fix #11 
